### PR TITLE
Authorisation Ontology V0.1.1

### DIFF
--- a/authentication-ontology.ttl
+++ b/authentication-ontology.ttl
@@ -1,0 +1,25 @@
+@base <https://data.federatief.datastelsel.nl/lock-unlock/authentication/model/def/>.
+@prefix : <https://data.kkg.kadaster.nl/authorisation/model#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+
+: rdf:type owl:Ontology;
+  owl:versionIRI :0.1.1.
+
+:has_role rdf:type owl:ObjectProperty;
+          rdfs:label "has_role";
+          rdfs:subPropertyOf owl:topObjectProperty;
+          rdfs:domain :User;
+          rdfs:range :Role;
+          rdfs:comment "Associates a user with one or more Roles, in accordance with section 2.1.4 of the paper by Jajodia et al. (2001)".
+
+:Role rdf:type owl:Class;
+      rdfs:label "Role";
+      rdfs:comment "In line with the paper by Jajodia et al. (2001) this has been renamed from Persona to Role.".
+
+
+:User rdf:type owl:Class;
+      rdfs:label "User";
+      rdfs:comment "A User is a natural person or autonomous system wishing to retrieve information from the dataset governed by the described authorisation policy.".

--- a/authentication-ontology.ttl
+++ b/authentication-ontology.ttl
@@ -1,5 +1,5 @@
 @base <https://data.federatief.datastelsel.nl/lock-unlock/authentication/model/def/>.
-@prefix : <https://data.kkg.kadaster.nl/authorisation/model#>.
+@prefix : <https://data.federatief.datastelsel.nl/lock-unlock/authentication/model/def/>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

--- a/authorisation-ontology.ttl
+++ b/authorisation-ontology.ttl
@@ -1,5 +1,5 @@
 @base <https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/>.
-@prefix : <https://data.kkg.kadaster.nl/authorisation/model#>.
+@prefix : <https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

--- a/authorisation-ontology.ttl
+++ b/authorisation-ontology.ttl
@@ -1,4 +1,4 @@
-@base <https://data.kkg.kadaster.nl/authorisation/model#>.
+@base <https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/>.
 @prefix : <https://data.kkg.kadaster.nl/authorisation/model#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
@@ -29,14 +29,6 @@
                  rdfs:subPropertyOf owl:topObjectProperty;
                  rdfs:domain :Endpoint;
                  rdfs:range :Dataset.
-
-
-:has_role rdf:type owl:ObjectProperty;
-          rdfs:label "has_role";
-          rdfs:subPropertyOf owl:topObjectProperty;
-          rdfs:domain :User;
-          rdfs:range :Role;
-          rdfs:comment "Associates a user with one or more Roles, in accordance with section 2.1.4 of the paper by Jajodia et al. (2001)".
 
 
 :has_rule rdf:type owl:ObjectProperty;
@@ -111,7 +103,3 @@ Was previously named 'precondition' in discussion, but this 'subject' less confu
                rdfs:label "SecurityGroup";
                rdfs:comment "A Security Group acts as an intermediary between Roles and Rules to allow clustering of similar access patterns.".
 
-
-:User rdf:type owl:Class;
-      rdfs:label "User";
-      rdfs:comment "A User is a natural person or autonomous system wishing to retrieve information from the dataset governed by the described authorisation policy.".

--- a/data/brk.auth.ttl
+++ b/data/brk.auth.ttl
@@ -1,6 +1,6 @@
 @prefix policy: <https://labs.kadaster.nl/unlocked/data/brk.auth#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix sse: <https://labs.kadaster.nl/unlocked/securedsparqlendpoint/>.
+@prefix sse: <https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/>.
 
 policy:public_types_access_rule a sse:AccessRule;
     rdfs:comment "Node types zijn altijd toegankelijk";

--- a/data/brp.auth.ttl
+++ b/data/brp.auth.ttl
@@ -1,6 +1,6 @@
 @prefix policy: <https://labs.kadaster.nl/unlocked/data/brp.auth#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix sse: <https://labs.kadaster.nl/unlocked/securedsparqlendpoint/>.
+@prefix sse: <https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/>.
 
 policy:public_types_access_rule a sse:AccessRule;
     rdfs:comment "Node types zijn altijd toegankelijk";

--- a/data/open.auth.ttl
+++ b/data/open.auth.ttl
@@ -1,6 +1,6 @@
 @prefix policy: <https://labs.kadaster.nl/unlocked/data/brp.auth#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix sse: <https://labs.kadaster.nl/unlocked/securedsparqlendpoint/>.
+@prefix sse: <https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/>.
 
 policy:everything_open a sse:AccessRule;
     rdfs:comment "Alles is toegankelijk";

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -10,12 +10,14 @@
 
 
 :applies_to_graph rdf:type owl:ObjectProperty;
+                  rdfs:label "applies_to_graph";
                   rdfs:subPropertyOf owl:topObjectProperty;
                   rdfs:domain :AccessRule;
                   rdfs:range :Graph.
 
 
 :belongs_to_group rdf:type owl:ObjectProperty;
+                  rdfs:label "belongs_to_group";
                   rdfs:subPropertyOf owl:topObjectProperty;
                   rdfs:domain :Role;
                   rdfs:range :SecurityGroup;
@@ -23,12 +25,14 @@
 
 
 :exposes_dataset rdf:type owl:ObjectProperty;
+                 rdfs:label "exposes_dataset";
                  rdfs:subPropertyOf owl:topObjectProperty;
                  rdfs:domain :Endpoint;
                  rdfs:range :Dataset.
 
 
 :has_role rdf:type owl:ObjectProperty;
+          rdfs:label "has_role";
           rdfs:subPropertyOf owl:topObjectProperty;
           rdfs:domain :User;
           rdfs:range :Role;
@@ -36,18 +40,21 @@
 
 
 :has_rule rdf:type owl:ObjectProperty;
+          rdfs:label "has_rule";
           rdfs:subPropertyOf owl:topObjectProperty;
           rdfs:domain :SecurityGroup;
           rdfs:range :AccessRule.
 
 
 :part_of_dataset rdf:type owl:ObjectProperty;
+                 rdfs:label "part_of_dataset";
                  rdfs:subPropertyOf owl:topObjectProperty;
                  rdfs:domain :Graph;
                  rdfs:range :Dataset.
 
 
 :condition rdf:type owl:DatatypeProperty;
+           rdfs:label "condition";
            rdfs:subPropertyOf owl:topDataProperty;
            rdfs:domain :AccessRule;
            rdfs:range xsd:string;
@@ -58,6 +65,7 @@ For example \"?bedrag rdf:type brk:Bedrag. ?perceel brk:laatsteKoopsom ?bedrag.\
 
 
 :subject rdf:type owl:DatatypeProperty;
+         rdfs:subject "subject";
          rdfs:subPropertyOf owl:topDataProperty;
          rdfs:domain :AccessRule;
          rdfs:range xsd:string;
@@ -70,6 +78,7 @@ Was previously named 'precondition' in discussion, but this 'subject' less confu
 
 
 :AccessRule rdf:type owl:Class;
+            rdfs:label "AccessRule";
             rdfs:subClassOf [ rdf:type owl:Restriction;
                               owl:onProperty :subject;
                               owl:cardinality "1"^^xsd:nonNegativeInteger
@@ -81,22 +90,28 @@ Was previously named 'precondition' in discussion, but this 'subject' less confu
             rdfs:comment "An Access Rule defines a section of the graph that is accessible to Users in its Security Group".
 
 
-:Dataset rdf:type owl:Class.
+:Dataset rdf:type owl:Class;
+         rdfs:label "Dataset".
 
 
-:Endpoint rdf:type owl:Class.
+:Endpoint rdf:type owl:Class;
+          rdfs:label "Endpoint".
 
 
-:Graph rdf:type owl:Class.
+:Graph rdf:type owl:Class;
+       rdfs:label "Graph".
 
 
 :Role rdf:type owl:Class;
+      rdfs:label "Role";
       rdfs:comment "In line with the paper by Jajodia et al. (2001) this has been renamed from Persona to Role.".
 
 
 :SecurityGroup rdf:type owl:Class;
+               rdfs:label "SecurityGroup";
                rdfs:comment "A Security Group acts as an intermediary between Roles and Rules to allow clustering of similar access patterns.".
 
 
 :User rdf:type owl:Class;
+      rdfs:label "User";
       rdfs:comment "A User is a natural person or autonomous system wishing to retrieve information from the dataset governed by the described authorisation policy.".

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -1,5 +1,5 @@
-@base <https://labs.kadaster.nl/unlocked/securedsparqlendpoint/>.
-@prefix : <https://labs.kadaster.nl/unlocked/securedsparqlendpoint/>.
+@base <https://data.kkg.kadaster.nl/authorisation/model#>.
+@prefix : <https://data.kkg.kadaster.nl/authorisation/model#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -6,7 +6,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 : rdf:type owl:Ontology;
-  owl:versionIRI :0.1.
+  owl:versionIRI :0.1.1.
 
 
 :applies_to_graph rdf:type owl:ObjectProperty;

--- a/src/main/java/nl/kadaster/labs/unlocked/securedsparqlendpoint/endpoints/SparqlEndpoint.java
+++ b/src/main/java/nl/kadaster/labs/unlocked/securedsparqlendpoint/endpoints/SparqlEndpoint.java
@@ -52,11 +52,11 @@ public class SparqlEndpoint {
                 Node.ANY,
                 Node.ANY,
                 NodeFactory.createURI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
-                NodeFactory.createURI("https://labs.kadaster.nl/unlocked/securedsparqlendpoint/AccessRule")
+                NodeFactory.createURI("https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/AccessRule")
         ).forEachRemaining(quad -> {
             var rule = quad.getSubject();
-            var subject = dataset.accessOntology.find(Node.ANY, rule, NodeFactory.createURI("https://labs.kadaster.nl/unlocked/securedsparqlendpoint/subject"), Node.ANY).next().getObject().getLiteralValue().toString();
-            var condition = dataset.accessOntology.find(Node.ANY, rule, NodeFactory.createURI("https://labs.kadaster.nl/unlocked/securedsparqlendpoint/condition"), Node.ANY).next().getObject().getLiteralValue().toString();
+            var subject = dataset.accessOntology.find(Node.ANY, rule, NodeFactory.createURI("https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/subject"), Node.ANY).next().getObject().getLiteralValue().toString();
+            var condition = dataset.accessOntology.find(Node.ANY, rule, NodeFactory.createURI("https://data.federatief.datastelsel.nl/lock-unlock/authorisation/model/def/condition"), Node.ANY).next().getObject().getLiteralValue().toString();
             var accessQuery = QueryFactory.create("CONSTRUCT {$subject} WHERE {$subject $condition}"
                     .replace("$subject", subject)
                     .replace("$condition", condition));


### PR DESCRIPTION
# Changes
- Add an `rdfs:label` to all concepts
- Change base URL
- Change version to 0.1.1

# Out of Scope
- Cardinality of `sse:condition` and `sse:subject`. (Hans Schevers)
To reach a proper decision on the cardinality of these properties, we must first decide how to decompose the condition and subject. If these become individual triples the cardinality will be different than if they are conceptually similar to a [TriplesBlock](https://www.w3.org/TR/sparql11-query/#rTriplesBlock).
- Support for both permission and prohibition in `sse:AccessRule`s. (@marcvanandel)
Supporting this also requires mechanisms for conflict resolution and world assumptions. I think this is better left for a later stage of the project, once we have demonstrated this version (0.1.X) works.